### PR TITLE
Fix warning

### DIFF
--- a/nv-ios-digest/MessageDigest.m
+++ b/nv-ios-digest/MessageDigest.m
@@ -72,7 +72,7 @@
     }
 
     // Get the length of the C-string.
-    CC_LONG len = strlen(str);
+    CC_LONG len = (CC_LONG)strlen(str);
 
     if (len == 0)
     {


### PR DESCRIPTION
Fix warning: Implicit conversion loses integer precision: 'unsigned long' to 'CC_LONG' (aka 'unsigned int')
